### PR TITLE
Fix bug related with EditText hint

### DIFF
--- a/app_test/src/androidTest/java/org/cookpad/stringspatcher/StringPatcherXMLTest.kt
+++ b/app_test/src/androidTest/java/org/cookpad/stringspatcher/StringPatcherXMLTest.kt
@@ -27,6 +27,7 @@ class StringPatcherXMLTest {
         onView(withText("value3 Updated!")).check(matches(isDisplayed()))
         onView(withText("value4 Updated!")).check(matches(isDisplayed()))
         onView(withId(R.id.etWithHintUpdated)).check(matches(withHint("value5 Updated!")))
+        onView(withId(R.id.etWithHintWithoutPatch)).check(matches(withHint("Value Without Patch")))
 
         onView(withId(R.id.btStringPatcherDebugEnabled)).perform(click())
         onView(withId(R.id.btRestartActivity)).perform(click())
@@ -36,5 +37,6 @@ class StringPatcherXMLTest {
         onView(withText("value3  📝  value3 Updated!")).check(matches(isDisplayed()))
         onView(withText("value4  📝  value4 Updated!")).check(matches(isDisplayed()))
         onView(withId(R.id.etWithHintUpdated)).check(matches(withHint("value5  📝  value5 Updated!")))
+        onView(withId(R.id.etWithHintWithoutPatch)).check(matches(withHint("valueWithoutPatch  📝  Value Without Patch")))
     }
 }

--- a/app_test/src/main/res/layout/app_test_activity.xml
+++ b/app_test/src/main/res/layout/app_test_activity.xml
@@ -55,7 +55,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="10dp"
-
                     android:orientation="vertical">
 
                     <TextView
@@ -69,7 +68,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="10dp"
-
                     android:orientation="vertical">
 
                     <EditText
@@ -77,6 +75,20 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:hint="@string/value5" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
+
+                    <EditText
+                        android:id="@+id/etWithHintWithoutPatch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/valueWithoutPatch" />
 
                 </LinearLayout>
 

--- a/app_test/src/main/res/values/strings.xml
+++ b/app_test/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="value3">value3</string>
     <string name="value4">value4</string>
     <string name="value5">value5</string>
+    <string name="valueWithoutPatch">Value Without Patch</string>
     <string name="restart_activity">Restart activity</string>
     <string name="string_patcher_debug_enabled">String patcher debug enabled</string>
 </resources>

--- a/strings_patcher/src/main/java/org/cookpad/strings_patcher/internal/AndroidUtils.kt
+++ b/strings_patcher/src/main/java/org/cookpad/strings_patcher/internal/AndroidUtils.kt
@@ -93,7 +93,13 @@ internal val bindTextView: (TextView) -> Unit = { textView ->
                 }
             }
 
-    val textFallback = (textView as? EditText)?.text?.toString() ?: textView.text
+    val textFallback: CharSequence
+    if (textView is EditText) {
+        textFallback = if (isHint) textView.hint else textView.text
+    } else {
+        textFallback = textView.text
+    }
+
     val text = (value ?: textFallback).addDebug(targetKey)
 
     if (isHint && textView is EditText) {


### PR DESCRIPTION
This PR solves a bug when a `EditText` has a `hint` but the string resource doesn't exist in the spreadsheet, so after apply the `StringsPatcher` the `hint` disappears